### PR TITLE
Update listas-y-objetos.js

### DIFF
--- a/tp-10/listas-y-objetos.js
+++ b/tp-10/listas-y-objetos.js
@@ -1,4 +1,4 @@
-var listaPersonasEjemplo = [
+const listaPersonasEjemplo = [
     {
         "apellido": "Perez",
         "nombre": "Juan",
@@ -22,18 +22,18 @@ var listaPersonasEjemplo = [
         "nombre": "Ana",
         "edad": 30,
         "documento": 45678
-    },
+    }
 ];
 
 //01 - ordenarPorApellido
 function ordenarPorApellido(listaDePersonas) {
-        return listaDePersonas.sort((a, b) => a.apellido.localeCompare(b.apellido));
-    }
-console.log("ordenarPorApellido()", ordenarPorApellido(listaPersonasEjemplo));
+    return listaDePersonas.sort((a, b) => a.apellido.localeCompare(b.apellido));
+}
+console.log("ordenarPorApellido()", ordenarPorApellido([...listaPersonasEjemplo]));
 
 //02 - soloNombres
 function soloNombres(listaDePersonas) {
-    return listaDePersonas.map(persona => persona.nombre); 
+    return listaDePersonas.map(persona => persona.nombre);
 }
 console.log("soloNombres()", soloNombres(listaPersonasEjemplo));
 


### PR DESCRIPTION
// Changes Summary:
// - Changed "var listaPersonasEjemplo" to "const listaPersonasEjemplo" to reflect modern best practices. // - Removed the trailing comma in the array definition for cleaner syntax. // - In the "ordenarPorApellido" function call, passed a shallow copy ([...listaPersonasEjemplo]) to avoid mutating the original array.